### PR TITLE
Adds support for source maps (Working)

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,6 @@ function process(plugins, css, filename) {
 		})
 		.then(result => ({
 				code: result.css,
-				map: result.map
-		}));
+				map: result.map.toJSON()
+		}))
 }

--- a/index.js
+++ b/index.js
@@ -16,15 +16,15 @@ module.exports = (context = {}) => {
 }
 
 function process(plugins, css, filename) {
-  return postcss(plugins)
-    .process(css, {
-      from: filename,
-      map: {
-        inline: false
-      }
-    })
-    .then(result => ({
-        code: result.css,
-        map: result.map
-    }));
+	return postcss(plugins)
+		.process(css, {
+			from: filename,
+			map: {
+				inline: false
+			}
+		})
+		.then(result => ({
+				code: result.css,
+				map: result.map
+		}));
 }

--- a/index.js
+++ b/index.js
@@ -5,12 +5,12 @@ module.exports = (context = {}) => {
 	const { useConfigFile = true, configFilePath, plugins = [] } = context
 
 	if (useConfigFile === false) {
-		return ({ content, fileName }) => Promise.resolve(process(plugins, content, fileName))
+		return ({ content, filename }) => Promise.resolve(process(plugins, content, filename))
 	} else {
 		const configPromise = postcssLoadConfig(context, configFilePath)
 
-		return ({ content, fileName }) => configPromise.then(
-			({ plugins }) => process(plugins, content, fileName)
+		return ({ content, filename }) => configPromise.then(
+			({ plugins }) => process(plugins, content, filename)
 		)
 	}
 }

--- a/index.js
+++ b/index.js
@@ -5,18 +5,26 @@ module.exports = (context = {}) => {
 	const { useConfigFile = true, configFilePath, plugins = [] } = context
 
 	if (useConfigFile === false) {
-		return ({ content }) => Promise.resolve(process(plugins, content))
+		return ({ content, fileName }) => Promise.resolve(process(plugins, content, fileName))
 	} else {
 		const configPromise = postcssLoadConfig(context, configFilePath)
 
-		return ({ content }) => configPromise.then(
-			({ plugins }) => process(plugins, content)
+		return ({ content, fileName }) => configPromise.then(
+			({ plugins }) => process(plugins, content, fileName)
 		)
 	}
 }
 
-function process(plugins, css) {
-	return postcss(plugins)
-		.process(css)
-		.then(code => ({ code }))
+function process(plugins, css, filename) {
+  return postcss(plugins)
+    .process(css, {
+      from: filename,
+      map: {
+        inline: false
+      }
+    })
+    .then(result => ({
+        code: result.css,
+        map: result.map
+    }));
 }


### PR DESCRIPTION
Adds support for source maps. This should be merged asap in light of sveltejs/svelte#1863.

Comparison with #4.

* postcss returns a `SourceMapGenerator` not a string or bare object. Before passing the sourcemap to svelte we convert it to a bare object
* It's `filename` not `fileName`