### PR TITLE
Allow PostCSS 7.x or 6.x peer dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postcss": "^6.0.16"
   },
   "peerDependencies": {
-    "postcss": "6.x"
+    "postcss": "7.x || 6.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified :-(\" && exit 0"


### PR DESCRIPTION
Not sure what to do about package lock file. Should that even be in the repo?